### PR TITLE
Remove is-not expressions with str

### DIFF
--- a/trackeval/eval.py
+++ b/trackeval/eval.py
@@ -96,7 +96,7 @@ class Evaluator:
                         res['COMBINED_SEQ'][c_cls] = {}
                         for metric, metric_name in zip(metrics_list, metric_names):
                             curr_res = {seq_key: seq_value[c_cls][metric_name] for seq_key, seq_value in res.items() if
-                                        seq_key is not 'COMBINED_SEQ'}
+                                        seq_key != 'COMBINED_SEQ'}
                             res['COMBINED_SEQ'][c_cls][metric_name] = metric.combine_sequences(curr_res)
                     # combine classes
                     if dataset.should_classes_combine:

--- a/trackeval/utils.py
+++ b/trackeval/utils.py
@@ -134,7 +134,7 @@ def load_detail(file):
             seq = row[0]
             if seq == 'COMBINED':
                 seq = 'COMBINED_SEQ'
-            if (len(current_values) == len(keys)) and seq:
+            if (len(current_values) == len(keys)) and seq != '':
                 data[seq] = {}
                 for key, value in zip(keys, current_values):
                     data[seq][key] = float(value)

--- a/trackeval/utils.py
+++ b/trackeval/utils.py
@@ -134,7 +134,7 @@ def load_detail(file):
             seq = row[0]
             if seq == 'COMBINED':
                 seq = 'COMBINED_SEQ'
-            if (len(current_values) == len(keys)) and seq is not '':
+            if (len(current_values) == len(keys)) and seq:
                 data[seq] = {}
                 for key, value in zip(keys, current_values):
                     data[seq][key] = float(value)


### PR DESCRIPTION
I believe it's not safe to use `is` to compare string values in python. It may work sometimes, but it depends on the python implementation. It's better to use ==.