### PR TITLE
Allow comparison_plots.py to take trackers name to include in plots as parameters

### DIFF
--- a/scripts/comparison_plots.py
+++ b/scripts/comparison_plots.py
@@ -16,5 +16,12 @@ classes = ['pedestrian']
 data_fol = os.path.join(tracker_folder, dataset)
 trackers = os.listdir(data_fol)
 out_loc = os.path.join(plots_folder, dataset)
+
+if len(sys.argv[1:]) > 0:
+    if not set(sys.argv[1:]).issubset(set(trackers)):
+        not_found_trackers = set(sys.argv[1:]) - set(trackers)
+        raise Exception(f"The following trackers could not be found in {data_fol}: {', '.join(not_found_trackers)}")
+    trackers = sys.argv[1:]
+
 for cls in classes:
     trackeval.plotting.plot_compare_trackers(data_fol, trackers, cls, out_loc)


### PR DESCRIPTION
Allow the `comparison_plots.py` script to take as parameters a list of trackers to include in the generated plots.
If no parameter is provided, all the trackers found in the trackers folder are included (default and previous behavior).
If a tracker name is provided as parameter but not found in the trackers folder, an exception is raised and the script stops.

It can be convenient in scripts (or even manually in the command line) to choose which trackers to include in the generated plots, without having to delete the folder of the "unwanted trackers" in the trackers/ folder.