### PR TITLE
🐛 HOTA: fix numpy error when either ground truth or tracks are empty.

### DIFF
--- a/trackeval/metrics/hota.py
+++ b/trackeval/metrics/hota.py
@@ -51,14 +51,15 @@ class HOTA(_BaseMetric):
 
         # First loop through each timestep and accumulate global track information.
         for t, (gt_ids_t, tracker_ids_t) in enumerate(zip(data['gt_ids'], data['tracker_ids'])):
-            # Count the potential matches between ids in each timestep
-            # These are normalised, weighted by the match similarity.
-            similarity = data['similarity_scores'][t]
-            sim_iou_denom = similarity.sum(0)[np.newaxis, :] + similarity.sum(1)[:, np.newaxis] - similarity
-            sim_iou = np.zeros_like(similarity)
-            sim_iou_mask = sim_iou_denom > 0 + np.finfo('float').eps
-            sim_iou[sim_iou_mask] = similarity[sim_iou_mask] / sim_iou_denom[sim_iou_mask]
-            potential_matches_count[gt_ids_t[:, np.newaxis], tracker_ids_t[np.newaxis, :]] += sim_iou
+            if len(gt_ids_t) and len(tracker_ids_t):
+                # Count the potential matches between ids in each timestep
+                # These are normalised, weighted by the match similarity.
+                similarity = data['similarity_scores'][t]
+                sim_iou_denom = similarity.sum(0)[np.newaxis, :] + similarity.sum(1)[:, np.newaxis] - similarity
+                sim_iou = np.zeros_like(similarity)
+                sim_iou_mask = sim_iou_denom > 0 + np.finfo('float').eps
+                sim_iou[sim_iou_mask] = similarity[sim_iou_mask] / sim_iou_denom[sim_iou_mask]
+                potential_matches_count[gt_ids_t[:, np.newaxis], tracker_ids_t[np.newaxis, :]] += sim_iou
 
             # Calculate the total number of dets for each gt_id and tracker_id.
             gt_id_count[gt_ids_t] += 1


### PR DESCRIPTION
fixes a bug where a numpy error occurred when one of the shape dimensions of the data was 0. This was causing the potential matches between IDs in each timestep to not be counted correctly. The fix introduced by if len(gt_ids_t) and len(tracker_ids_t): ensures that the potential matches are only counted if both gt_ids_t and tracker_ids_t are non-empty, which prevents the numpy error from occurring. This ensures that the potential matches are calculated correctly, resulting in more accurate tracking results.